### PR TITLE
add special cases learned from NEO TestNet

### DIFF
--- a/tests/arithmetics-tests/arithmetics.Test.cpp
+++ b/tests/arithmetics-tests/arithmetics.Test.cpp
@@ -184,10 +184,37 @@ TEST(csBIArithmeticsTests, ZeroGreaterThanErrorIsFalse)
 
 // ============ special
 
+TEST(csBIArithmeticsTests, SpecialDiv)
+{
+   BigInteger b1 = BigInteger("41483775933600000000");
+   BigInteger b2 = BigInteger("414937759336");
+   EXPECT_EQ(b1 / b2, BigInteger("99975899"));
+}
+
+TEST(csBIArithmeticsTests, SpecialDiv2)
+{
+   BigInteger b1 = BigInteger("-11001000000");
+   BigInteger b2 = BigInteger(86400);
+   EXPECT_EQ(b1 / b2, BigInteger(-127326));
+}
+
+TEST(csBIArithmeticsTests, SpecialMod)
+{
+   BigInteger b1 = BigInteger("20195283520469175757");
+   BigInteger b2 = BigInteger("1048576");
+   EXPECT_EQ(b1 % b2, BigInteger("888269"));
+}
+
+
 // 860593 % -201 is 112
 TEST(csBIArithmeticsTests, SpecialModNeg)
 {
    EXPECT_EQ(BigInteger(860593) % BigInteger(-201), BigInteger(112));
+}
+
+TEST(csBIArithmeticsTests, SpecialModNeg2)
+{
+   EXPECT_EQ(BigInteger("-18224909727634776050312394179610579601844989529623334093909233530432892596607") % BigInteger("14954691977398614017"), BigInteger("-3100049211437790421"));  
 }
 
 // TODO: add these bunch of tests https://github.com/dotnet/corefx/tree/master/src/System.Runtime.Numerics/tests/BigInteger

--- a/tests/serialize-tests/serialize.Test.cpp
+++ b/tests/serialize-tests/serialize.Test.cpp
@@ -1159,3 +1159,33 @@ TEST(csBISerializeTests, BigInteger_0_padding_hex)
    BigInteger big("0", 16);
    EXPECT_EQ(big.toHexStr(), "00");
 }
+
+TEST(csBISerializeTests, BigInteger_Special1)
+{
+   BigInteger big(128);
+   EXPECT_EQ(big.toHexStr(), "8000");
+}
+
+TEST(csBISerializeTests, BigInteger_Special2)
+{
+   BigInteger big("-48335248028225339427907476932896373492484053930");
+   EXPECT_EQ(big.toHexStr().length() / 2, 20);
+}
+
+TEST(csBISerializeTests, BigInteger_Special3)
+{
+   BigInteger big("-399990000");
+   EXPECT_EQ(big.toHexStr(), "10a328e8");
+}
+
+//negative left shift should be positive right shift
+TEST(csBISerializeTests, BigInteger_Special4)
+{
+   EXPECT_EQ(BigInteger(8) << BigInteger(-3), 1);
+}
+
+//negative right shift should be positive left shift
+TEST(csBISerializeTests, BigInteger_Special5)
+{
+   EXPECT_EQ(BigInteger(8) >> BigInteger(-3), 64);
+}


### PR DESCRIPTION
There are a couple of special cases I ran into with neo-python from which I learned various deviations in the Python language. I think they are worth making part of the default tests